### PR TITLE
chore: regenerate v0.38 protos using latest version

### DIFF
--- a/proto/src/prost/v0_38/tendermint.privval.rs
+++ b/proto/src/prost/v0_38/tendermint.privval.rs
@@ -69,8 +69,26 @@ pub struct PingRequest {}
 pub struct PingResponse {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SignRawBytesRequest {
+    #[prost(string, tag = "1")]
+    pub chain_id: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "2")]
+    pub raw_bytes: ::prost::alloc::vec::Vec<u8>,
+    #[prost(string, tag = "3")]
+    pub unique_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SignedRawBytesResponse {
+    #[prost(bytes = "vec", tag = "1")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag = "2")]
+    pub error: ::core::option::Option<RemoteSignerError>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Message {
-    #[prost(oneof = "message::Sum", tags = "1, 2, 3, 4, 5, 6, 7, 8")]
+    #[prost(oneof = "message::Sum", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
     pub sum: ::core::option::Option<message::Sum>,
 }
 /// Nested message and enum types in `Message`.
@@ -94,6 +112,10 @@ pub mod message {
         PingRequest(super::PingRequest),
         #[prost(message, tag = "8")]
         PingResponse(super::PingResponse),
+        #[prost(message, tag = "9")]
+        SignRawBytesRequest(super::SignRawBytesRequest),
+        #[prost(message, tag = "10")]
+        SignedRawBytesResponse(super::SignedRawBytesResponse),
     }
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]

--- a/proto/src/tendermint/v0_38.rs
+++ b/proto/src/tendermint/v0_38.rs
@@ -61,6 +61,6 @@ pub mod version {
 }
 
 pub mod meta {
-    pub const REPOSITORY: &str = "https://github.com/cometbft/cometbft";
-    pub const COMMITISH: &str = "v0.38.12";
+    pub const REPOSITORY: &str = "https://github.com/rach-id/cometbft";
+    pub const COMMITISH: &str = "d503f6dec0f41c8524bb25025bb6b2f2d9def1ce";
 }

--- a/tools/proto-compiler/src/constants.rs
+++ b/tools/proto-compiler/src/constants.rs
@@ -27,9 +27,9 @@ pub const TENDERMINT_VERSIONS: &[TendermintVersion] = &[
         commitish: "v0.37.11",
     },
     TendermintVersion {
-        repo: "https://github.com/cometbft/cometbft",
+        repo: "https://github.com/rach-id/cometbft",
         ident: "v0_38",
-        commitish: "v0.38.12",
+        commitish: "d503f6dec0f41c8524bb25025bb6b2f2d9def1ce",
     },
 ];
 


### PR DESCRIPTION
This PR regenerates the privval protos to match the latest changes that will be merged in the v0.38.x branch in cometBFT: https://github.com/cometbft/cometbft/pull/5138

* [ ] Referenced an issue explaining the need for the change
* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Added entry in `.changelog/`
